### PR TITLE
Durable and dont auto delete

### DIFF
--- a/taskflow/engines/worker_based/proxy.py
+++ b/taskflow/engines/worker_based/proxy.py
@@ -112,7 +112,7 @@ class Proxy(object):
 
         # create exchange
         self._exchange = kombu.Exchange(name=self._exchange_name,
-                                        durable=False, auto_delete=True)
+                                        durable=True, auto_delete=False)
 
     @property
     def dispatcher(self):
@@ -148,8 +148,8 @@ class Proxy(object):
         """Make a named queue for the given exchange."""
         queue_name = "%s_%s" % (self._exchange_name, routing_key)
         return kombu.Queue(name=queue_name,
-                           routing_key=routing_key, durable=False,
-                           exchange=exchange, auto_delete=True,
+                           routing_key=routing_key, durable=True,
+                           exchange=exchange, auto_delete=False,
                            channel=channel)
 
     def publish(self, msg, routing_key, reply_to=None, correlation_id=None):

--- a/taskflow/examples/99_bottles.py
+++ b/taskflow/examples/99_bottles.py
@@ -37,8 +37,8 @@ from taskflow.patterns import linear_flow as lf
 from taskflow.persistence import backends as persistence_backends
 from taskflow.persistence import models
 from taskflow import task
-from taskflow.types import timing
 
+from oslo_utils import timeutils
 from oslo_utils import uuidutils
 
 # Instructions!
@@ -122,7 +122,7 @@ def run_conductor(only_run_once=False):
         print("Event '%s' has been received..." % event)
         print("Details = %s" % details)
         if event.endswith("_start"):
-            w = timing.StopWatch()
+            w = timeutils.StopWatch()
             w.start()
             base_event = event[0:-len("_start")]
             event_watches[base_event] = w

--- a/taskflow/types/timing.py
+++ b/taskflow/types/timing.py
@@ -16,13 +16,7 @@
 
 import threading
 
-from debtcollector import moves
-from oslo_utils import timeutils
 import six
-
-# TODO(harlowja): Keep alias class... around until 2.0 is released.
-StopWatch = moves.moved_class(timeutils.StopWatch, 'StopWatch', __name__,
-                              version="1.15", removal_version="2.0")
 
 
 class Timeout(object):


### PR DESCRIPTION
The conductor didn't get a response back, crashed, and the resulting exchanges in use by the workers were auto-purged, including the queues in the exchange, which caused cascade of rabbitmq failures (404 - queue doesn't exist) in the workers.  This should stop this behavior.